### PR TITLE
Fix: Resolve undefined variable error in includecode shortcode

### DIFF
--- a/layouts/shortcodes/includecode.html
+++ b/layouts/shortcodes/includecode.html
@@ -53,7 +53,9 @@
   
   {{- /* If still not found, show error */ -}}
   {{- if not $found -}}
-    {{- $content = printf "Error: Could not read file '%s'. Tried the following paths:\n- Site-relative: %s\n- Page-relative: %s\n- Absolute: %s" $file $siteRelativePath $pageRelativePath $absolutePath -}}
+    {{- $pageRelativePath := printf "%s%s" .Page.File.Dir $file -}}
+    {{- $absolutePath := printf "/%s" $file -}}
+    {{- $content = printf "Error: Could not read file '%s'. Tried the following paths:\n- Site-relative: %s\n- Page-relative: %s\n- Absolute: %s" $file $file $pageRelativePath $absolutePath -}}
   {{- end -}}
 
   {{- if $lines -}}


### PR DESCRIPTION
## Problem
The `includecode` shortcode was failing with a template parsing error:
```
parse of template failed: template: _shortcodes/includecode.html:56: undefined variable "$siteRelativePath"
```

## Solution
Fixed undefined variables in the error message block by:
- Defining `$pageRelativePath` and `$absolutePath` variables within the error block scope
- Using `$file` for the site-relative path reference in error message
- Ensuring proper error reporting when file paths cannot be resolved

## Changes
- `layouts/shortcodes/includecode.html`: Fixed undefined variable references in error message

## Testing
- [x] Template parses without errors
- [x] Shortcode functions correctly for valid file paths
- [x] Error messages display properly for invalid file paths

This is a critical hotfix that resolves a build-breaking template error.