### PR TITLE
fix: Update Hugo GitHub Action to support deploy functionality

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -26,10 +26,11 @@ jobs:
           role-to-assume: ${{ secrets.TERRAFORM_AWS_DEPLOY_ROLE }}
           role-session-name: HugoDeploy
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v3
+        uses: noesya/actions-hugo@release
         with:
           hugo-version: 'latest'
           extended: true
+          withdeploy: true
       - name: hugo mod tidy
         run: hugo mod tidy
       - name: hugo npm pack

--- a/content/posts/hugo-aws-complete-guide/github-actions-cicd/index.md
+++ b/content/posts/hugo-aws-complete-guide/github-actions-cicd/index.md
@@ -219,9 +219,11 @@ jobs:
           aws-region: us-east-2
 
       - name: Set up Hugo
-        uses: peaceiris/actions-hugo@v2
+        uses: noesya/actions-hugo@release
         with:
-          hugo-version: '0.125.0'
+          hugo-version: 'latest'
+          extended: true
+          withdeploy: true
 
       - name: Build
         run: hugo --minify
@@ -230,6 +232,8 @@ jobs:
         run: |
           hugo deploy --maxDeletes -1
 ```
+
+> **Important**: We're using `noesya/actions-hugo@release` instead of the more common `peaceiris/actions-hugo` because the peaceiris action doesn't support Hugo's deploy functionality. The `withdeploy: true` parameter ensures Hugo is built with deploy support, which is required for the `hugo deploy` command to work with S3.
 
 Notice how we're using the `aws-actions/configure-aws-credentials` action with OIDC instead of hardcoded access keys. The `permissions` section is crucial—it grants the workflow the ability to request an identity token that AWS can verify.
 


### PR DESCRIPTION
Switch from peaceiris/actions-hugo to noesya/actions-hugo@release to resolve "deploy not supported" error when running hugo deploy command.

Changes:
- Replace peaceiris/actions-hugo@v3 with noesya/actions-hugo@release
- Add withdeploy: true parameter to enable Hugo deploy functionality
- Update hugo-version to 'latest' with extended: true
- Add documentation explaining why noesya action is required

Also update blog post documentation to:
- Reflect the correct Hugo action configuration
- Explain the importance of withdeploy parameter
- Prevent readers from encountering the same deploy error

Resolves: "Error: deploy not supported in this version of Hugo"
Fixes: GitHub Actions workflow failing on hugo deploy command